### PR TITLE
Add CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.19)
+
+# name + version from configure.ac's AC_INIT
+project(tunneler LANGUAGES C VERSION 1.1.1)
+
+find_package(SDL REQUIRED)
+
+# values from autotools-generated config.h
+set(PACKAGE "${CMAKE_PROJECT_NAME}")
+set(PACKAGE_BUGREPORT "tvkalvas@jyu.fi")
+set(PACKAGE_NAME "${CMAKE_PROJECT_NAME}")
+set(PACKAGE_STRING "${CMAKE_PROJECT_NAME} ${CMAKE_PROJECT_VERSION}")
+set(PACKAGE_TARNAME "${CMAKE_PROJECT_NAME}")
+set(PACKAGE_URL "")
+set(PACKAGE_VERSION "${CMAKE_PROJECT_VERSION}")
+set(VERSION "${CMAKE_PROJECT_VERSION}")
+configure_file(src/config.h.cmake-in src/config.h)
+
+add_executable(tunneler
+               src/ai.c
+               src/graphics.c
+               src/keys.c
+               src/main.c
+               src/terrain.c
+               src/timer.c
+               src/tunneler.c)
+# for config.h
+target_include_directories(tunneler PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/src")
+target_link_libraries(tunneler PRIVATE SDL::SDL m)

--- a/src/config.h.cmake-in
+++ b/src/config.h.cmake-in
@@ -1,0 +1,25 @@
+/* src/config.h.cmake-in. Created based on autotools-generated template. */
+
+/* Name of package */
+#cmakedefine PACKAGE "@PACKAGE@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME "@PACKAGE_NAME@"
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME "@PACKAGE_TARNAME@"
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL "@PACKAGE_URL@"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION "@PACKAGE_VERSION@"
+
+/* Version number of package */
+#cmakedefine VERSION "@VERSION@"


### PR DESCRIPTION
Including a config.h generation similar to autotools. The values hardcoded in CMakeLists.txt are derived from the values included in config.h generated by

  autoreconf -i && ./configure

The added src/config.h.cmake-in defines the same macros as the autotools process does.

Tested with:

  cmake -H. -Bbuild && cmake --build build && ./build/tunneler